### PR TITLE
Added ripple effect on touch

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ export default class Ripple extends PureComponent {
     rippleCentered: false,
     rippleSequential: false,
     rippleFades: true,
-    rippleOnTouch: true,
+    rippleOnPressIn: true,
     disabled: false,
 
     onRippleAnimation: (animation, callback) => animation.start(callback),
@@ -33,7 +33,7 @@ export default class Ripple extends PureComponent {
     rippleCentered: PropTypes.bool,
     rippleSequential: PropTypes.bool,
     rippleFades: PropTypes.bool,
-    rippleOnTouch: PropTypes.bool,
+    rippleOnPressIn: PropTypes.bool,
     disabled: PropTypes.bool,
 
     onRippleAnimation: PropTypes.func,
@@ -82,14 +82,14 @@ export default class Ripple extends PureComponent {
 
   onPress(event) {
     let { ripples } = this.state;
-    let { onPress, rippleSequential, rippleOnTouch } = this.props;
+    let { onPress, rippleSequential, rippleOnPressIn } = this.props;
 
     if (!rippleSequential || !ripples.length) {
       if ('function' === typeof onPress) {
         requestAnimationFrame(() => onPress(event));
       }
 
-      if (!rippleOnTouch)
+      if (!rippleOnPressIn)
         this.startRipple(event);
     }
   }
@@ -105,13 +105,13 @@ export default class Ripple extends PureComponent {
   }
 
   onPressIn(event) {
-    let { onPressIn, rippleOnTouch } = this.props;
+    let { onPressIn, rippleOnPressIn } = this.props;
 
     if ('function' === typeof onPressIn) {
       onPressIn(event);
     }
 
-    if (rippleOnTouch)
+    if (rippleOnPressIn)
       this.startRipple(event);
   }
 
@@ -230,7 +230,7 @@ export default class Ripple extends PureComponent {
       rippleCentered,
       rippleSequential,
       rippleFades,
-      rippleOnTouch,
+      rippleOnPressIn,
 
       ...props
     } = this.props;

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ export default class Ripple extends PureComponent {
     rippleCentered: false,
     rippleSequential: false,
     rippleFades: true,
+    rippleOnTouch: true,
     disabled: false,
 
     onRippleAnimation: (animation, callback) => animation.start(callback),
@@ -32,6 +33,7 @@ export default class Ripple extends PureComponent {
     rippleCentered: PropTypes.bool,
     rippleSequential: PropTypes.bool,
     rippleFades: PropTypes.bool,
+    rippleOnTouch: PropTypes.bool,
     disabled: PropTypes.bool,
 
     onRippleAnimation: PropTypes.func,
@@ -80,14 +82,15 @@ export default class Ripple extends PureComponent {
 
   onPress(event) {
     let { ripples } = this.state;
-    let { onPress, rippleSequential } = this.props;
+    let { onPress, rippleSequential, rippleOnTouch } = this.props;
 
     if (!rippleSequential || !ripples.length) {
       if ('function' === typeof onPress) {
         requestAnimationFrame(() => onPress(event));
       }
 
-      this.startRipple(event);
+      if (!rippleOnTouch)
+        this.startRipple(event);
     }
   }
 
@@ -102,11 +105,14 @@ export default class Ripple extends PureComponent {
   }
 
   onPressIn(event) {
-    let { onPressIn } = this.props;
+    let { onPressIn, rippleOnTouch } = this.props;
 
     if ('function' === typeof onPressIn) {
       onPressIn(event);
     }
+
+    if (rippleOnTouch)
+      this.startRipple(event);
   }
 
   onPressOut(event) {
@@ -224,6 +230,7 @@ export default class Ripple extends PureComponent {
       rippleCentered,
       rippleSequential,
       rippleFades,
+      rippleOnTouch,
 
       ...props
     } = this.props;

--- a/readme.md
+++ b/readme.md
@@ -62,6 +62,7 @@ class Example extends Component {
  rippleCentered              | Ripple always starts from center       |  Boolean | false
  rippleSequential            | Ripple should start in sequence        |  Boolean | false
  rippleFades                 | Ripple fades out                       |  Boolean | true
+ rippleOnTouch               | Starts ripple animation on touch       |  Boolean | true
  disabled                    | Ripple should ignore touches           |  Boolean | false
  onPressIn                   | Touch moved in or started callback     | Function | -
  onPressOut                  | Touch moved out or terminated callback | Function | -

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ class Example extends Component {
  rippleCentered              | Ripple always starts from center       |  Boolean | false
  rippleSequential            | Ripple should start in sequence        |  Boolean | false
  rippleFades                 | Ripple fades out                       |  Boolean | true
- rippleOnTouch               | Starts ripple animation on touch       |  Boolean | true
+ rippleOnPressIn             | Starts ripple animation on touch       |  Boolean | true
  disabled                    | Ripple should ignore touches           |  Boolean | false
  onPressIn                   | Touch moved in or started callback     | Function | -
  onPressOut                  | Touch moved out or terminated callback | Function | -


### PR DESCRIPTION
Now the ripple effect is triggered as soon as the user touches the screen. This causes a better user experience and better mimics the native effect.

Previously the ripple effect was triggered only when the user took the finger off the screen.

The ripple on touch can be disabled by **rippleOnTouch** property.